### PR TITLE
Moved `x_features = cnn(x.unsqueeze(0))` outside the denoising loop, …

### DIFF
--- a/NoProp.ipynb
+++ b/NoProp.ipynb
@@ -631,8 +631,8 @@
         "# Inference (denoising)\n",
         "def predict(x):\n",
         "    z_t = torch.randn(1, embed_dim)  # Start from noise\n",
+        "    x_features = cnn(x.unsqueeze(0))\n",
         "    for t in reversed(range(T)):\n",
-        "        x_features = cnn(x.unsqueeze(0))\n",
         "        u_hat = mlps[t](x_features, z_t)\n",
         "        z_t = torch.sqrt(alpha[t]) * u_hat + torch.sqrt(1 - alpha[t]) * torch.randn_like(u_hat)\n",
         "    return torch.argmax(z_t)  # Final prediction"


### PR DESCRIPTION
…Image features are now computed once and reused across all T denoising steps

This PR fixes a suboptimal implementation in the `predict()` function where image features were unnecessarily re-computed during each denoising step.